### PR TITLE
Vanilla JS example with server-side route to get image.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 FFMPEG_jll = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
 Genie = "c43c736e-a2d1-11e8-161f-af95117fbd1e"
+HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 Stipple = "4acbeb90-81a0-11ea-1966-bdaff8155998"
 StippleUI = "a3c5d34a-b254-4859-a8fa-b86abb7e84a3"

--- a/mwe.jl
+++ b/mwe.jl
@@ -1,13 +1,11 @@
-using Stipple, StippleUI, FFMPEG_jll
+using Stipple, StippleUI
 using Genie.Renderer.Html
+using HTTP
 
 const IMGPATH = "img/demo.png"
 
 const SZ = 240 # width and height of the images
 const FPS = 10 # frames per second
-ffmpeg() do exe # record from camera a frame, rewriting to `IMGPATH` 10 (= `FPS`) times a second
-    run(`$exe -y -hide_banner -loglevel error -f v4l2 -video_size $(SZ)x$SZ -i /dev/video0 -r $FPS -update 1 public/$IMGPATH`, wait = false)
-end
 
 Base.@kwdef mutable struct Dashboard1 <: ReactiveModel # all this stuff with the model, is not really used here. I just keep it for the call to dashboard below
 end
@@ -24,18 +22,38 @@ function ui()
                """
                        setInterval(function() {
                        var img = document.getElementById("frame");
-                       img.src = "$IMGPATH#" + new Date().getTime();
-                       }, 500);
+                       img.src = "frame/" + new Date().getTime();
+                       }, 1000);
                """
-              ),
+              ),        
         heading("Image Demo"),
         row(cell(class="st-module", [
-            quasar(:img, id = "frame", src = IMGPATH, style="height: 140px; max-width: 140px")
+            """
+                <img id="frame" src="frame" style="height: 140px; max-width: 140px" />
+            """
+            # the quasar thing doesn't actually create an img tag
+            # instead, it uses a div with a background image
+            # and it makes up its own ids, so you lose the "frame" id
+            # which is why the vanilla js doesn't work
+            # quasar(:img, id = "frame", src = "frame", style="height: 140px; max-width: 140px")
         ]))
     ], title = "Image Demo") |> html
 end
 
+function getframe()
+    # here's where you'd put your code to grab the image from the camera
+    # you'd then return an HTTP.Response object to stream the image back to the browser
+    # https://github.com/JuliaWeb/HTTP.jl
+    # this way, you never have to write anything to the disk
+    # that'll have the benefit of speeding things up (I/O is slow)
+    # and you won't have to clean up all of those frames from wherever they're being written
+    return HTTP.request("GET", "https://cataas.com/cat") 
+end
+
 route("/", ui)
+
+# this is our new route which returns the image
+route("/frame/:timestamp", getframe)
 
 Genie.config.server_host = "127.0.0.1"
 


### PR DESCRIPTION
This change just illustrates what I had in mind when I suggested to have a separate route to serve the images...

You'll notice that i created the route "frame/:timestamp" which retrieves a cat image and then sends it back to the client. So, the idea would be that in this route, you'd grab the current frame from the video stream and send it back instead. That way, you wouldn't have to be constantly writing the frame image out to the disk.

But I'll have to take another look at the StippleUI/quasar stuff. Basically, with the current model (using that setTimeout function), the browser is the one initiating the request for a new frame. But the StippleUI package will basically let you invert that, and have the server "push" new frames out to the browser using WebSockets. I'll poke around at that later tonight if I have time.

